### PR TITLE
ARGO-770 AMS Library tests

### DIFF
--- a/pymod/__init__.py
+++ b/pymod/__init__.py
@@ -8,5 +8,5 @@ except ImportError:
 logging.getLogger(__name__).addHandler(NullHandler())
 
 from .ams import ArgoMessagingService
-from .amsexceptions import (AmsServiceException, AmsConnectionException, AmsException)
+from .amsexceptions import (AmsServiceException, AmsConnectionException, AmsMessageException, AmsException)
 from .amsmsg import AmsMessage

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -53,7 +53,7 @@ class ArgoMessagingService:
             if e.code == 404:
                 return False
             else:
-                return True
+                raise e
 
         except AmsConnectionException as e:
             raise e
@@ -137,7 +137,7 @@ class ArgoMessagingService:
             if e.code == 404:
                 return False
             else:
-                return True
+                raise e
 
         except AmsConnectionException as e:
             raise e

--- a/pymod/amsexceptions.py
+++ b/pymod/amsexceptions.py
@@ -15,3 +15,8 @@ class AmsConnectionException(AmsException):
     def __init__(self, exp, request):
         self.msg = "While trying the [{0}]: {1}".format(request, repr(exp))
         super(AmsConnectionException, self).__init__(self.msg)
+
+class AmsMessageException(AmsException):
+    def __init__(self, msg):
+        self.msg = msg
+        super(AmsMessageException, self).__init__(self.msg)

--- a/pymod/amsmsg.py
+++ b/pymod/amsmsg.py
@@ -5,16 +5,15 @@ from collections import Callable
 from amsexceptions import AmsMessageException
 
 class AmsMessage(Callable):
-    def __init__(self, callable=False, b64enc=True, attributes=None, data=None,
+    def __init__(self, b64enc=True, attributes=None, data=None,
                  messageId=None, publishTime=None):
         self._attributes = attributes
         self._messageId = messageId
         self._publishTime = publishTime
-        self._callable = callable
         self.set_data(data, b64enc)
 
     def __call__(self, **kwargs):
-        self.__init__(callable=True, b64enc=True, **kwargs)
+        self.__init__(b64enc=True, **kwargs)
 
         return self.dict()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,8 +67,8 @@ class TestClient(unittest.TestCase):
             resp_pull = self.ams.pull_sub("subscription1", 1)
             ack_id, msg = resp_pull[0]
             assert ack_id == "projects/TEST/subscriptions/subscription1:1221"
-            assert msg.data == "YmFzZTY0ZW5jb2RlZA=="
-            assert msg.messageId == "1221"
+            assert msg.get_data() == "base64encoded"
+            assert msg.get_msgid() == "1221"
             # Note: Maybe ack_sub should return a boolean
             resp_ack = self.ams.ack_sub("subscription1", ["1221"])
             assert resp_ack == {}

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,7 +8,6 @@ class TestMessage(unittest.TestCase):
     def setUp(self):
         m = AmsMessage()
         self.message_callable = m(attributes={'foo': 'bar'}, data='baz')
-        self.message_callable_nodata = m(attributes={'foo': 'bar'})
         self.message_send = AmsMessage(attributes={'foo': 'bar'}, data='baz')
         self.message_send_no_data = AmsMessage(attributes={'foo': 'bar'})
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,43 @@
+import unittest
+
+from pymod import AmsMessage
+from pymod import AmsMessageException
+
+class TestMessage(unittest.TestCase):
+
+    def setUp(self):
+        m = AmsMessage()
+        self.message_callable = m(attributes={'foo': 'bar'}, data='baz')
+        self.message_callable_nodata = m(attributes={'foo': 'bar'})
+        self.message_send = AmsMessage(attributes={'foo': 'bar'}, data='baz')
+        self.message_send_no_data = AmsMessage(attributes={'foo': 'bar'})
+
+        self.message_recv = AmsMessage(b64enc=False, attributes={'foo': 'bar'},
+                                       data='YmF6', messageId='1',
+                                       publishTime='2017-03-15T17:11:34.035345612Z')
+        self.message_recv_faulty = AmsMessage(b64enc=False, attributes={'foo': 'bar'},
+                                              data='123456789thiswillfail',
+                                              messageId='1',
+                                              publishTime='2017-03-15T17:11:34.035345612Z')
+
+    def test_MsgReadyToSend(self):
+        self.assertEqual(self.message_send.dict(), {'attributes': {'foo': 'bar'},
+                                                    'data': 'YmF6'})
+        self.assertEqual(self.message_callable, {'attributes': {'foo': 'bar'},
+                                                 'data': 'YmF6'})
+        self.message_send.set_data('baz')
+        self.assertEqual(self.message_send.get_data(), 'baz')
+
+    def test_MsgReadyToRecv(self):
+        self.assertEqual(self.message_recv.get_data(), 'baz')
+        self.assertEqual(self.message_recv.get_msgid(), '1')
+        self.assertEqual(self.message_recv.get_publishtime(),
+                         '2017-03-15T17:11:34.035345612Z')
+        self.assertEqual(self.message_recv.get_attr(), {'foo': 'bar'})
+
+    def test_MsgFaulty(self):
+        self.assertRaises(AmsMessageException, self.message_recv_faulty.get_data)
+        self.assertRaises(AmsMessageException, self.message_send_no_data.get_data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -8,6 +8,7 @@ class TestMessage(unittest.TestCase):
     def setUp(self):
         m = AmsMessage()
         self.message_callable = m(attributes={'foo': 'bar'}, data='baz')
+        self.message_callable_memoization = m(attributes={'foo1': 'bar1'})
         self.message_send = AmsMessage(attributes={'foo': 'bar'}, data='baz')
         self.message_send_no_data = AmsMessage(attributes={'foo': 'bar'})
 
@@ -23,6 +24,8 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(self.message_send.dict(), {'attributes': {'foo': 'bar'},
                                                     'data': 'YmF6'})
         self.assertEqual(self.message_callable, {'attributes': {'foo': 'bar'},
+                                                 'data': 'YmF6'})
+        self.assertEqual(self.message_callable_memoization, {'attributes': {'foo1': 'bar1'},
                                                  'data': 'YmF6'})
         self.message_send.set_data('baz')
         self.assertEqual(self.message_send.get_data(), 'baz')


### PR DESCRIPTION
- added tests for AmsMessage
- introduced AmsMessageException needed in case Base64 decoding errors or message data not set
