### PR TITLE
ARGO-1120 Extend AMS client to support X509 method via the authentica…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ If you want the devel instance so as to test all new features
 If you want the stable instance you may download it from here
 http://rpm-repo.argo.grnet.gr/ARGO/prod/centos6/
 
+## Authentication
+The ams library uses a valid ams token to execute requests against the ams cluster.
+This token can be provided with 2 ways:
+
+- Obtain a valid ams token and then use it when initializing the ams object.
+```python
+from argo_ams_library import ArgoMessagingService
+ams = ArgoMessagingService(endpoint="ams_endpoint", project="ams_project", token="your_ams_token")
+```
+
+- Use a valid certificate
+```python
+from argo_ams_library import ArgoMessagingService
+ams = ArgoMessagingService(endpoint="ams_endpoint", project="ams_project", cert="/path/to/cert", key="/path/to/cert/key")
+```
+The library will use the provided certificate to access the corresponding ams token through [the ARGO Authentication Service](https://github.com/ARGOeu/argo-api-authn) and then set the ams object's token field with the retrieved token.
 
 ## Examples
 

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -31,7 +31,8 @@ class AmsHttpRequests(object):
                        "sub_getacl": ["get", "https://{0}/v1/projects/{2}/subscriptions/{3}:acl?key={1}"],
                        "sub_modifyacl": ["post", "https://{0}/v1/projects/{2}/subscriptions/{3}:modifyAcl?key={1}"],
                        "sub_offsets": ["get", "https://{0}/v1/projects/{2}/subscriptions/{3}:offsets?key={1}"],
-                       "sub_mod_offset": ["post", "https://{0}/v1/projects/{2}/subscriptions/{3}:modifyOffset?key={1}"]}
+                       "sub_mod_offset": ["post", "https://{0}/v1/projects/{2}/subscriptions/{3}:modifyOffset?key={1}"],
+                       "auth_x509": ["get", "https://{0}:{1}/v1/service-types/ams/hosts/{0}:authX509"]}
         # HTTP error status codes returned by AMS according to:
         # http://argoeu.github.io/messaging/v1/api_errors/
         self.errors_route = {"topic_create": ["put", set([409, 401, 403])],
@@ -42,6 +43,7 @@ class AmsHttpRequests(object):
                              "sub_get": ["get", set([404, 401, 403])],
                              "topic_publish": ["post", set([413, 401, 403])],
                              "sub_pushconfig": ["post", set([400, 401, 403, 404])],
+                             "auth_x509": ["post", set([400, 401, 403, 404])],
                              "sub_pull": ["post", set([400, 401, 403, 404])]}
 
     def _make_request(self, url, body=None, route_name=None, **reqkwargs):
@@ -170,16 +172,76 @@ class ArgoMessagingService(AmsHttpRequests):
        calls that are wrapped in series of methods. Class is entry point for
        client code.
     """
-    def __init__(self, endpoint, token="", project=""):
+    def __init__(self, endpoint, token="", project="", cert="", key="", authn_port=8443):
         super(ArgoMessagingService, self).__init__()
+        self.authn_port = authn_port
+        self.token = ""
         self.endpoint = endpoint
-        self.token = token
         self.project = project
+        self.assign_token(token, cert, key)
         self.pullopts = {"maxMessages": "1",
                          "returnImmediately": "false"}
         # Containers for topic and subscription objects
         self.topics = dict()
         self.subs = dict()
+
+    def assign_token(self, token, cert, key):
+        """
+        Assign a token to the ams object
+
+        Args:
+            token(str): a valid ams token
+            cert(str): a path to a valid certificate file
+            key(str): a path to the associated key file for the provided certificate
+        """
+
+        # check if a token has been provided
+        if token != "":
+            self.token = token
+            return
+
+        try:
+            # otherwise use the provided certificate to retrieve it
+            self.token = self.auth_via_cert(cert, key)
+        except AmsServiceException as e:
+            if e.message["error"] == 'While trying the [auth_x509]: No certificate provided.':
+                e.message["error"] += "No token provided"
+                raise e
+
+    def auth_via_cert(self, cert, key, **reqkwargs):
+        """
+           Retrieve an ams token based on the provided certificate
+
+            Args:
+                cert(str): a path to a valid certificate file
+                key(str): a path to the associated key file for the provided certificate
+
+           Kwargs:
+               reqkwargs: keyword argument that will be passed to underlying
+                          python-requests library call.
+        """
+        if cert == "" and key == "":
+            errord = {"error": {"code": 400, "message": "No certificate provided."}}
+            raise AmsServiceException(json=errord, request="auth_x509")
+
+        # create the certificate tuple needed by the requests library
+        reqkwargs = {"cert": (cert, key)}
+
+        route = self.routes["auth_x509"]
+
+        # Compose url
+        url = route[1].format(self.endpoint, self.authn_port)
+        method = getattr(self, 'do_{0}'.format(route[0]))
+
+        try:
+            r = method(url, "auth_x509", **reqkwargs)
+            # if the `token` field was not found in the response, raise an error
+            if "token" not in r:
+                errord = {"error": {"code": 500, "message": "Token was not found in the response.Response: " + str(r)}}
+                raise AmsServiceException(json=errord, request="auth_x509")
+            return r["token"]
+        except (AmsServiceException, AmsConnectionException) as e:
+            raise e
 
     def _create_sub_obj(self, s, topic):
         self.subs.update({s['name']: AmsSubscription(s['name'], topic,

--- a/tests/test_authenticate.py
+++ b/tests/test_authenticate.py
@@ -1,0 +1,93 @@
+import unittest
+from pymod import ArgoMessagingService
+from pymod import AmsServiceException
+from httmock import urlmatch, HTTMock, response
+
+
+class TestAuthenticate(unittest.TestCase):
+
+    # tests the case of providing wrong file path for cert
+    def test_auth_via_cert_invalid_cert(self):
+
+        try:
+            _ = ArgoMessagingService(endpoint="localhost", project="TEST", cert="/cert/path")
+        except Exception as e:
+            assert isinstance(e, IOError)
+            self.assertEqual(e.message, "Could not find the TLS certificate file, invalid path: /cert/path")
+            # tests the case of providing wrong file paths
+
+    # tests the case of providing wrong file path for key
+    def test_auth_via_cert_invalid_key(self):
+
+        try:
+            _ = ArgoMessagingService(endpoint="localhost", project="TEST", key="/cert/key")
+        except Exception as e:
+            assert isinstance(e, IOError)
+            self.assertEqual(e.message, "Could not find the TLS key file, invalid path: /cert/key")
+
+    # tests the case of providing empty arguments for the cert and key
+    def test_auth_via_cert_cert(self):
+
+        try:
+            ams = ArgoMessagingService(endpoint="localhost", token="s3cret", project="TEST")
+            ams.auth_via_cert("","")
+        except Exception as e:
+            assert isinstance(e, AmsServiceException)
+            self.assertEqual(e.message, {'status_code': 400, 'error': 'While trying the [auth_x509]: No certificate provided.'})
+
+    # tests the case of providing empty arguments for token and cert
+    def test_auth_via_cert_empty_token_and_cert(self):
+
+        try:
+            ams = ArgoMessagingService(endpoint="localhost", project="TEST")
+        except Exception as e:
+            assert isinstance(e, AmsServiceException)
+            self.assertEqual(e.message, {'status_code': 400, 'error': 'While trying the [auth_x509]: No certificate provided.No token provided'})
+
+    # tests the case of providing a token
+    def test_assign_token(self):
+        ams = ArgoMessagingService(endpoint="localhost", token="some_token", project="TEST")
+        self.assertEqual(ams.token, "some_token")
+
+    # tests the successful retrieval of a token
+    def test_auth_via_cert_success(self):
+
+        auth_via_cert_urlmatch = dict(netloc="localhost",
+                                      path="/v1/service-types/ams/hosts/localhost:authX509",
+                                      method='GET')
+
+        # Mock response for successful token retrieval
+        @urlmatch(**auth_via_cert_urlmatch)
+        def auth_via_cert_success(url, request):
+            assert url.path == "/v1/service-types/ams/hosts/localhost:authX509"
+            return response(200, '{"token":"success_token"}', None, None, 5, request)
+
+        # Execute ams client with mocked response
+        with HTTMock(auth_via_cert_success):
+            ams = ArgoMessagingService(endpoint="localhost", project="TEST", cert="/path/cert", key="/path/key")
+            self.assertEqual(ams.token, "success_token")
+
+    # tests the case where the response doesn't contain the `token` field
+    def test_auth_via_cert_missing_token_field(self):
+
+        auth_via_cert_urlmatch = dict(netloc="localhost",
+                                      path="/v1/service-types/ams/hosts/localhost:authX509",
+                                      method='GET')
+
+        # Mock response for successful token retrieval
+        @urlmatch(**auth_via_cert_urlmatch)
+        def auth_via_cert_missing_field(url, request):
+            assert url.path == "/v1/service-types/ams/hosts/localhost:authX509"
+            return response(200, '{"other_field":"success_token"}', None, None, 5, request)
+
+        # Execute ams client with mocked response
+        with HTTMock(auth_via_cert_missing_field):
+            try:
+                ams = ArgoMessagingService(endpoint="localhost", project="TEST", cert="/path/cert", key="/path/key")
+                ams.auth_via_cert("/path/cert", "/path/key")
+            except Exception as e:
+                assert isinstance(e, AmsServiceException)
+                self.assertEqual(e.message, {'status_code': 500, 'error': "While trying the [auth_x509]: Token was not found in the response.Response: {u'other_field': u'success_token'}"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Functionality to support conversion of x509 cert to ams token.
When creating an ams object, you can no specify the path to a cert and key file instead of a token and the service will react and try to grab an ams token associated with the provided certificate.
Also, if the user doesnt't provide neither a token nor a cert and key file errors will be raised.

@vrdel Should i also add an example? 