### PR TITLE
Make all print statements Python 3 compatible

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.abspath('.'))
 #    if os.environ['DEVDIR']:
 #        devdir = os.environ['DEVDIR']
 #except KeyError:
-#    print 'Unable to obtain $DEVDIR from the environment.'
+#    print('Unable to obtain $DEVDIR from the environment.')
 #    exit(-1)
 
 #sys.path.insert(0, os.path.abspath('.'))

--- a/examples/consume-pull.py
+++ b/examples/consume-pull.py
@@ -23,7 +23,7 @@ def main():
         if not ams.has_sub(args.subscription):
             ams.create_sub(args.subscription, args.topic)
     except AmsException as e:
-        print e
+        print(e)
         raise SystemExit(1)
 
     # try to pull number of messages from subscription. method will
@@ -34,7 +34,7 @@ def main():
         data = msg.get_data()
         msgid = msg.get_msgid()
         attr = msg.get_attr()
-        print 'msgid={0}, data={1}, attr={2}'.format(msgid, data, attr)
+        print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
         ackids.append(id)
 
     # pass list of extracted ackIds to AMS Service so that

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -19,7 +19,7 @@ def main():
         if not ams.has_topic(args.topic):
             ams.create_topic(args.topic)
     except AmsException as e:
-        print e
+        print(e)
         raise SystemExit(1)
 
     # publish one message to given topic. message is constructed with
@@ -29,9 +29,9 @@ def main():
     msg = AmsMessage(data='foo1', attributes={'bar1': 'baz1'}).dict()
     try:
         ret = ams.publish(args.topic, msg)
-        print ret
+        print(ret)
     except AmsException as e:
-        print e
+        print(e)
 
     # publish a list of two messages to given topic. AmsMessage can also be
     # used as a callable. publish() method accepts either one messages or
@@ -41,8 +41,8 @@ def main():
                msg(data='foo3', attributes={'bar3': 'baz3'})]
     try:
         ret = ams.publish(args.topic, msglist)
-        print ret
+        print(ret)
     except AmsException as e:
-        print e
+        print(e)
 
 main()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def get_ver():
                 if "Version:" in line:
                     return line.split()[1]
     except IOError:
-        print "Make sure that %s is in directory"  % (NAME+'.spec')
+        print("Make sure that %s is in directory"  % (NAME+'.spec'))
         raise SystemExit(1)
 
 setup(


### PR DESCRIPTION
When running APEL-SSM unit tests on Python 3, the first failure is from installing argo-ams-library as it uses the `print` statements that are incompatible with Python 3. Adding the brackets makes them compatible with Python 3 and doesn't affect Python 2 where they are ignored.

Python 2 will no longer be supported in 2020.