### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,8 @@ install:
     - "pip install httmock"
 
 script: nosetests
+
+# Cache the dependencies installed by pip
+cache: pip
+# Avoid pip log from affecting cache
+before_cache: rm -fv ~/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ language: python
 # Target py version 2.6
 python:
   - "2.6"
+  - "2.7"
+  - "3.5"
+  - "3.6"
+
+matrix:
+  allow_failures:
+    - python: "3.5"
+    - python: "3.6"
+  fast_finish: true
 
 # Pin Ubuntu version to Trusty for Python 2.6 support
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python:
   - "2.6"
 
+# Pin Ubuntu version to Trusty for Python 2.6 support
+dist: trusty
+
 install:
     - "pip install requests"
     - "pip install httmock"


### PR DESCRIPTION
This PR fixes the Travis build which would have been failing since Travis updated the default Ubuntu version to one that doesn't have Python 2.6 available. It also adds Python 3 builds, though they're allowed to fail, and pip caching to speed up the build (slightly).