### PR TITLE
Update to supported Python versions in Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,10 @@
 language: python
-# Target py version 2.6
+
 python:
-  - "2.6"
   - "2.7"
   - "3.5"
   - "3.6"
-
-matrix:
-  allow_failures:
-    - python: "3.5"
-    - python: "3.6"
-  fast_finish: true
-
-# Pin Ubuntu version to Trusty for Python 2.6 support
-dist: trusty
+  - "3.7"
 
 install:
     - "pip install requests"


### PR DESCRIPTION
With the merge of #86 and the Travis Python 3 tests now passing, I thought it would be good to update the Travis config to use all the supported versions of Python. However, I'm not sure if you still need Python 2.6 support.