### PR TITLE
ARGO-1481 Connection retry logic in ams-library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
+*.gitignore
+*.ropeproject
 *.pyc
+__pycache__
+*.values
+MANIFEST
+*.gz
+*.rpm
+*.pyc
+*.egg*
+*egg-info*
+.tox*
+coverage.xml
+.coverage

--- a/argo-ams-library.spec
+++ b/argo-ams-library.spec
@@ -91,6 +91,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Dec 4 2019 Daniel Vrcic <dvrcic@srce.hr> - 0.5.0-1%{?dist}
+- ARGO-1481 Connection retry logic in ams-library 
 * Fri Nov 8 2019 Daniel Vrcic <dvrcic@srce.hr>, agelostsal <agelos.tsal@gmail.com> - 0.4.3-1%{?dist}
 - ARGO-1990 Fix runtime dependencies
 - ARGO-1862 Make argo-ams-library Python 3 ready

--- a/argo-ams-library.spec
+++ b/argo-ams-library.spec
@@ -6,7 +6,7 @@
 
 Name:           argo-ams-library
 Summary:        %{sum} 
-Version:        0.4.2
+Version:        0.4.3
 Release:        1%{?dist}
 
 Group:          Development/Libraries
@@ -91,6 +91,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Nov 8 2019 Daniel Vrcic <dvrcic@srce.hr>, agelostsal <agelos.tsal@gmail.com> - 0.4.3-1%{?dist}
+- ARGO-1990 Fix runtime dependencies
+- ARGO-1862 Make argo-ams-library Python 3 ready
+- ARGO-1841 Update the ams library to include the new timeToOffset functionality
 * Thu Jul 26 2018 agelostsal <agelos.tsal@gmail.com> - 0.4.2-1%{?dist}
 - ARGO-1479 Subscription create methods don't delegate **reqkwargs where needed
 - Error handling bug during list_topic route

--- a/argo-ams-library.spec
+++ b/argo-ams-library.spec
@@ -6,7 +6,7 @@
 
 Name:           argo-ams-library
 Summary:        %{sum} 
-Version:        0.4.3
+Version:        0.5.0
 Release:        1%{?dist}
 
 Group:          Development/Libraries

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -152,9 +152,9 @@ class AmsHttpRequests(object):
                         saved_exp = e
                         time.sleep(sleep_secs)
                         if timeout:
-                            log.warning('Backoff retry #{0} after {1} seconds, connection timeout set to {2} seconds'.format(i, sleep_secs, timeout))
+                            log.warning('Backoff retry #{0} after {1} seconds, connection timeout set to {2} seconds - {3}'.format(i, sleep_secs, timeout, e))
                         else:
-                            log.warning('Backoff retry #{0} after {1} seconds'.format(i, sleep_secs))
+                            log.warning('Backoff retry #{0} after {1} seconds - {3}'.format(i, sleep_secs, e))
                     finally:
                         i += 1
                 else:
@@ -170,9 +170,9 @@ class AmsHttpRequests(object):
                     else:
                         time.sleep(retrysleep)
                         if timeout:
-                            log.warning('Retry #{0} after {1} seconds, connection timeout set to {2} seconds'.format(i, retrysleep, timeout))
+                            log.warning('Retry #{0} after {1} seconds, connection timeout set to {2} seconds - {3}'.format(i, retrysleep, timeout, e))
                         else:
-                            log.warning('Retry #{0} after {1} seconds'.format(i, retrysleep))
+                            log.warning('Retry #{0} after {1} seconds - {2}'.format(i, retrysleep, e))
                 finally:
                     i += 1
 

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -154,7 +154,7 @@ class AmsHttpRequests(object):
                         if timeout:
                             log.warning('Backoff retry #{0} after {1} seconds, connection timeout set to {2} seconds - {3}'.format(i, sleep_secs, timeout, e))
                         else:
-                            log.warning('Backoff retry #{0} after {1} seconds - {3}'.format(i, sleep_secs, e))
+                            log.warning('Backoff retry #{0} after {1} seconds - {2}'.format(i, sleep_secs, e))
                     finally:
                         i += 1
                 else:


### PR DESCRIPTION
This one prints exceptions on retries:

`
2019-12-05 10:57:27 argo_ams_library.ams[25976]: WARNING - Retry #6 after 60 seconds, connection timeout set to 180 seconds - {'status_code': 504, 'error': "While trying the [sub_pull]: <html><body><h1>504 Gateway Time-out</h1>\nThe server didn't respond in time.\n</body></html>\n"}
`