### PR TITLE
Test helper tool coverage version lock to 4.5.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,3 @@ deps = coverage==4.5.4
        requests260: requests==2.6.0
        requests2125: requests==2.12.5
 commands = coverage run -m pytest
-

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27-requests0, py27-requests260, py34-requests2123, py36-requests0, py36-requests2125
 
 [testenv]
-deps = coverage
+deps = coverage==4.5.4
        pytest
        httmock
        mock


### PR DESCRIPTION
`coverage 5` data storage has changed to SQLite instead of previous JSON files for the `coverage 4`. Since containers used for testing have `coverage 4` installed and are expecting JSON files, stick to lastest `4` release for a while.