### PR TITLE
ARGO-2182  ams-lib does not retry on topic publish

### DIFF
--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -937,7 +937,8 @@ class ArgoMessagingService(AmsHttpRequests):
         # Compose url
         url = route[1].format(self.endpoint, self.token, self.project, "", sub)
         method = getattr(self, 'do_{0}'.format(route[0]))
-        method(url, msg_body, "sub_ack", **reqkwargs)
+        method(url, msg_body, "sub_ack", retry=retry, retrysleep=retrysleep,
+               retrybackoff=retrybackoff, **reqkwargs)
 
         return True
 

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -802,7 +802,9 @@ class ArgoMessagingService(AmsHttpRequests):
         url = route[1].format(self.endpoint, self.token, self.project, topic)
         method = getattr(self, 'do_{0}'.format(route[0]))
 
-        return method(url, msg_body, "topic_publish", **reqkwargs)
+        return method(url, msg_body, "topic_publish", retry=retry,
+                      retrysleep=retrysleep, retrybackoff=retrybackoff,
+                      **reqkwargs)
 
     def list_subs(self, **reqkwargs):
         """Lists all subscriptions in a project with a GET request.


### PR DESCRIPTION
This is a small bugfix that passes retry parameters for topic publish method. 