### PR TITLE
ARGO-2360 Fix ack_sub retry loop

### DIFF
--- a/examples/retry.py
+++ b/examples/retry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from argparse import ArgumentParser
 from argo_ams_library import ArgoMessagingService, AmsMessage, AmsException
@@ -49,7 +49,7 @@ def main():
                     timeout=5)
 
     # backoff with each next retry attempt exponentially longer
-    msg = AmsMessage(data='foo1', attributes={'bar1': 'baz1'}).dict()
+    msg = AmsMessage(data='foo2', attributes={'bar2': 'baz2'}).dict()
     try:
         ret = ams.publish(args.topic, msg, retry=3, retrybackoff=5, timeout=5)
         print(ret)
@@ -70,5 +70,25 @@ def main():
     if ackids:
         ams.ack_sub(args.subscription, ackids, retrybackoff=3, retrysleep=5,
                     timeout=5)
+
+    # static sleep between retry attempts
+    msg = AmsMessage(data='foo3', attributes={'bar3': 'baz3'}).dict()
+    try:
+        ret = ams.publish(args.topic, msg, retry=3, retrysleep=5, timeout=5)
+        print(ret)
+    except AmsException as e:
+        print(e)
+
+    try:
+        msgs = ams.pullack_sub(args.subscription, args.nummsgs, retry=3,
+                               retrysleep=5, timeout=5)
+    except AmsException as e:
+        print(e)
+
+    for msg in msgs:
+        data = msg.get_data()
+        msgid = msg.get_msgid()
+        attr = msg.get_attr()
+        print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
 
 main()

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -44,6 +44,10 @@ def main():
         print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
         ackids.append(id)
 
+    if ackids:
+        ams.ack_sub(args.subscription, ackids, retry=3, retrysleep=5,
+                    timeout=5)
+
     # backoff with each next retry attempt exponentially longer
     msg = AmsMessage(data='foo1', attributes={'bar1': 'baz1'}).dict()
     try:
@@ -62,5 +66,9 @@ def main():
         attr = msg.get_attr()
         print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
         ackids.append(id)
+
+    if ackids:
+        ams.ack_sub(args.subscription, ackids, retrybackoff=3, retrysleep=5,
+                    timeout=5)
 
 main()

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -68,8 +68,7 @@ def main():
         ackids.append(id)
 
     if ackids:
-        ams.ack_sub(args.subscription, ackids, retrybackoff=3, retrysleep=5,
-                    timeout=5)
+        ams.ack_sub(args.subscription, ackids)
 
     # static sleep between retry attempts. this example uses consume context
     # method that pull and acks msgs in one call.

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -82,13 +82,13 @@ def main():
     try:
         msgs = ams.pullack_sub(args.subscription, args.nummsgs, retry=3,
                                retrysleep=5, timeout=5)
+        for msg in msgs:
+            data = msg.get_data()
+            msgid = msg.get_msgid()
+            attr = msg.get_attr()
+            print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
+
     except AmsException as e:
         print(e)
-
-    for msg in msgs:
-        data = msg.get_data()
-        msgid = msg.get_msgid()
-        attr = msg.get_attr()
-        print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
 
 main()

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -71,7 +71,8 @@ def main():
         ams.ack_sub(args.subscription, ackids, retrybackoff=3, retrysleep=5,
                     timeout=5)
 
-    # static sleep between retry attempts
+    # static sleep between retry attempts. this example uses consume context
+    # method that pull and acks msgs in one call.
     msg = AmsMessage(data='foo3', attributes={'bar3': 'baz3'}).dict()
     try:
         ret = ams.publish(args.topic, msg, retry=3, retrysleep=5, timeout=5)

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -159,7 +159,10 @@ class AmsHttpRequests(object):
                     finally:
                         i += 1
                 else:
-                    raise saved_exp
+                    if saved_exp:
+                        raise saved_exp
+                    else:
+                        raise e
 
         else:
             while i <= retry + 1:

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -954,7 +954,7 @@ class ArgoMessagingService(AmsHttpRequests):
            eventually passed to _retry_make_request(). If succesfull
            subscription pull immediately follows with failed acknownledgment
            (e.g. network hiccup just before acknowledgement of received
-           messages), consume cycle will reset and start from begginning with
+           messages), consume cycle will reset and start from beginning with
            new subscription pull. This ensures that ack deadline time window is
            moved to new start period, that is the time when the second pull was
            initiated.
@@ -993,7 +993,6 @@ class ArgoMessagingService(AmsHttpRequests):
                 break
 
         return messages
-
 
     def set_pullopt(self, key, value):
         """Function for setting pull options

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -947,11 +947,14 @@ class ArgoMessagingService(AmsHttpRequests):
 
     def pullack_sub(self, sub, num=1, return_immediately=False, retry=0,
                     retrysleep=60, retrybackoff=None, **reqkwargs):
+        ackIds = None
+        messages = None
 
-        ackIds = list()
-        messages = list()
         while True:
             try:
+                ackIds = list()
+                messages = list()
+
                 for id, msg in self.pull_sub(sub, num,
                                              return_immediately=return_immediately,
                                              retry=retry,
@@ -967,7 +970,8 @@ class ArgoMessagingService(AmsHttpRequests):
             try:
                 self.ack_sub(sub, ackIds, **reqkwargs)
                 break
-            except AmsException:
+            except AmsException as e:
+                log.warning('Continuing with sub_pull after sub_ack: {0}'.format(e))
                 pass
 
         return messages

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -945,6 +945,34 @@ class ArgoMessagingService(AmsHttpRequests):
 
         return True
 
+    def pullack_sub(self, sub, num=1, return_immediately=False, retry=0,
+                    retrysleep=60, retrybackoff=None, **reqkwargs):
+
+        ackIds = list()
+        messages = list()
+        while True:
+            try:
+                for id, msg in self.pull_sub(sub, num,
+                                             return_immediately=return_immediately,
+                                             retry=retry,
+                                             retrysleep=retrysleep,
+                                             retrybackoff=retrybackoff,
+                                             **reqkwargs):
+                    ackIds.append(id)
+                    messages.append(msg)
+
+            except AmsException as e:
+                raise e
+
+            try:
+                self.ack_sub(sub, ackIds, **reqkwargs)
+                break
+            except AmsException:
+                pass
+
+        return messages
+
+
     def set_pullopt(self, key, value):
         """Function for setting pull options
 

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -964,12 +964,15 @@ class ArgoMessagingService(AmsHttpRequests):
             except AmsException as e:
                 raise e
 
-            try:
-                self.ack_sub(sub, ackIds, **reqkwargs)
+            if messages and ackIds:
+                try:
+                    self.ack_sub(sub, ackIds, **reqkwargs)
+                    break
+                except AmsException as e:
+                    log.warning('Continuing with sub_pull after sub_ack: {0}'.format(e))
+                    pass
+            else:
                 break
-            except AmsException as e:
-                log.warning('Continuing with sub_pull after sub_ack: {0}'.format(e))
-                pass
 
         return messages
 

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -947,6 +947,24 @@ class ArgoMessagingService(AmsHttpRequests):
 
     def pullack_sub(self, sub, num=1, return_immediately=False, retry=0,
                     retrysleep=60, retrybackoff=None, **reqkwargs):
+        """Pull messages from subscription and acknownledge them in one call.
+
+           If enabled (retry > 0), multiple subscription pulls will be tried in
+           case of problems/glitches with the AMS service. retry* options are
+           eventually passed to _retry_make_request(). If succesfull
+           subscription pull immediately follows with failed acknownledgment
+           (e.g. network hiccup just before acknowledgement of received
+           messages), consume cycle will reset and start from begginning with
+           new subscription pull. This ensures that ack deadline time window is
+           moved to new start period, that is the time when the second pull was
+           initiated.
+
+           Args:
+               sub: str. The subscription name.
+               num: int. The number of messages to pull.
+               reqkwargs: keyword argument that will be passed to underlying
+                          python-requests library call.
+        """
         while True:
             try:
                 ackIds = list()

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -947,9 +947,6 @@ class ArgoMessagingService(AmsHttpRequests):
 
     def pullack_sub(self, sub, num=1, return_immediately=False, retry=0,
                     retrysleep=60, retrybackoff=None, **reqkwargs):
-        ackIds = None
-        messages = None
-
         while True:
             try:
                 ackIds = list()

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -951,13 +951,14 @@ class ArgoMessagingService(AmsHttpRequests):
 
            If enabled (retry > 0), multiple subscription pulls will be tried in
            case of problems/glitches with the AMS service. retry* options are
-           eventually passed to _retry_make_request(). If succesfull
-           subscription pull immediately follows with failed acknownledgment
-           (e.g. network hiccup just before acknowledgement of received
-           messages), consume cycle will reset and start from beginning with
-           new subscription pull. This ensures that ack deadline time window is
-           moved to new start period, that is the time when the second pull was
-           initiated.
+           eventually passed to _retry_make_request().
+
+           If succesfull subscription pull immediately follows with failed
+           acknownledgment (e.g. network hiccup just before acknowledgement of
+           received messages), consume cycle will reset and start from
+           beginning with new subscription pull. This ensures that ack deadline
+           time window is moved to new start period, that is the time when the
+           second pull was initiated.
 
            Args:
                sub: str. The subscription name.

--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -916,8 +916,7 @@ class ArgoMessagingService(AmsHttpRequests):
 
         return list(map(lambda m: (m['ackId'], AmsMessage(b64enc=False, **m['message'])), msgs))
 
-    def ack_sub(self, sub, ids, retry=0, retrysleep=60, retrybackoff=None,
-                **reqkwargs):
+    def ack_sub(self, sub, ids, **reqkwargs):
         """Acknownledgment of received messages
 
            Messages retrieved from a pull subscription can be acknowledged by
@@ -940,8 +939,7 @@ class ArgoMessagingService(AmsHttpRequests):
         # Compose url
         url = route[1].format(self.endpoint, self.token, self.project, "", sub)
         method = getattr(self, 'do_{0}'.format(route[0]))
-        method(url, msg_body, "sub_ack", retry=retry, retrysleep=retrysleep,
-               retrybackoff=retrybackoff, **reqkwargs)
+        method(url, msg_body, "sub_ack", **reqkwargs)
 
         return True
 

--- a/pymod/amssubscription.py
+++ b/pymod/amssubscription.py
@@ -70,7 +70,40 @@ class AmsSubscription(object):
                [(ackId, AmsMessage)]: List of tuples with ackId and AmsMessage instance
         """
 
-        return self.init.pull_sub(self.name, num=num, return_immediately=return_immediately, **reqkwargs)
+        return self.init.pull_sub(self.name, num=num,
+                                  return_immediately=return_immediately,
+                                  **reqkwargs)
+
+    def pullack(self, num=1, retry=0, retrysleep=60, retrybackoff=None,
+                return_immediately=False, **reqkwargs):
+        """Pull messages from subscription and acknownledge them in one call.
+
+          If succesfull subscription pull immediately follows with failed
+          acknownledgment (e.g. network hiccup just before acknowledgement of
+          received messages), consume cycle will reset and start from
+          begginning with new subscription pull.
+
+           Kwargs:
+               num (int): Number of messages to pull
+               retry: int. Number of request retries before giving up. Default
+                           is 0 meaning no further request retry will be made
+                           after first unsuccesfull request.
+               retrysleep: int. Static number of seconds to sleep before next
+                           request attempt
+               retrybackoff: int. Backoff factor to apply between each request
+                             attempts
+               return_immediately (boolean): If True and if stream of messages is empty,
+                                             subscriber call will not block and wait for
+                                             messages
+               reqkwargs: keyword argument that will be passed to underlying
+                          python-requests library call.
+           Return:
+               [AmsMessage1, AmsMessage2]: List of AmsMessage instances
+        """
+
+        return self.init.pullack_sub(self.name, num=num,
+                                     return_immediately=return_immediately,
+                                     **reqkwargs)
 
     def time_to_offset(self, timestamp, **reqkwargs):
         """

--- a/tests/test_errorclient.py
+++ b/tests/test_errorclient.py
@@ -270,16 +270,20 @@ class TestErrorClient(unittest.TestCase):
                                                      "message": "Ams Timeout",\
                                                      "status": "TIMEOUT"}}'
 
-        mock_requests_post.return_value = mock_pull_response
-        # mock_requests_post.side_effect = [mock_pull_response, mock_failedack_response]
+        mock_successack_response = mock.create_autospec(requests.Response)
+        mock_successack_response.status_code = 200
+        mock_successack_response.content = '200 OK'
+
+        mock_requests_post.side_effect = [mock_pull_response,
+                                          mock_failedack_response,
+                                          mock_pull_response,
+                                          mock_successack_response]
 
         resp_pullack = self.ams.pullack_sub("subscription1", 1)
         assert isinstance(resp_pullack, list)
         assert isinstance(resp_pullack[0], AmsMessage)
         self.assertEqual(resp_pullack[0].get_data(), "base64encoded")
-
-
-
+        self.assertEqual(resp_pullack[0].get_msgid(), "1221")
 
 
 if __name__ == '__main__':

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -180,7 +180,6 @@ class TestSubscription(unittest.TestCase):
                                                  "min": 0})
             self.assertRaises(AmsException, sub2.offsets, offset='bogus', move_to=79)
 
-
     def testDelete(self):
         # Mock response for DELETE topic request
         @urlmatch(netloc="localhost", path="/v1/projects/TEST/subscriptions/subscription1",


### PR DESCRIPTION
Introduced `pullack_sub()` method that is aware of consume cycle (`sub_pull`, `sub_ack`). Pull of messages from subscription is immediately followed by their acknownledgment. Method returns list of pulled messages that have been acknowlegded so client does not need to store the IDs and do the acknownledge by himself. 

It's introduced to prevent the "faulty acknowledgment retry loops" on the consuming side. That happens when `sub_pull` and `sub_ack` have retry enabled, `sub_pull` succedes but network hiccup happens and `sub_ack` fails and it keeps failing until the number of retries is exhausted. It's so because consume cycle is not "restarted" and `sub_ack` endlessly tries to acknowledge received messages out of ackDeadline time window (default 10 seconds while retrysleep > 10 seconds). 

This methods solves that by having `sub_pull` and `sub_ack` in same context so in such occasions when `sub_ack` fails, it will return back to `sub_pull` that will move the start of ackDeadline time window to a new period. 

Example is given in `example/retry.py`. Log messages that indicates this:
```
Continuing with sub_pull after sub_ack: While trying the [sub_ack]: ConnectionError(ProtocolError('Connection aborted.', error(101, 'Network is unreachable')),)
Retry #1 after 5 seconds, connection timeout set to 5 seconds - msg-devel.argo.grnet.gr: While trying the [sub_pull]: ConnectionError(ProtocolError('Connection aborted.', error(101, 'Network is unreachable')),)                                                       
Retry #2 after 5 seconds, connection timeout set to 5 seconds - msg-devel.argo.grnet.gr: While trying the [sub_pull]: ConnectionError(ProtocolError('Connection aborted.', error(101, 'Network is unreachable')),)    
```