### PR TITLE
ARGO-2768 ams-library: support for AMS authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ MANIFEST
 .tox*
 coverage.xml
 .coverage
+.idea

--- a/tests/amsmocks.py
+++ b/tests/amsmocks.py
@@ -85,7 +85,7 @@ class SubMocks(object):
     @urlmatch(**get_sub_timeTooffet_urlmatch)
     def timetooffset_sub_mock(self, url, request):
         assert url.path == "/v1/projects/TEST/subscriptions/subscription1:timeToOffset"
-        assert url.query.split("&")[1] == "time=2019-09-02T13:39:11.500Z"
+        assert url.query == "time=2019-09-02T13:39:11.500Z"
         # Return the offset for a subscription1
         return response(200, '{"offset": 44}', None, None, 5, request)
 


### PR DESCRIPTION
Following the change of the AMS service to incorporate the **x-api-key** header for its authorization/authentication.

1) Refactor the API routes in order to remove the extra placeholder for the key URL parameter
2) Refactor the ArgoMessagingService class's methods to not use the token field anymore
3) Introduce the x-api-key header assignment to the **_make_request** method of AmsHttpRequests class. Since all AMS requests require the header token in order to be completed, the assignment happens at a central place.
4) Move around some fields and methods required for the authn mapping to better accommodate step 3
5) Minor test changes to match the new functionality