### PR TITLE
AM-264 argo-ams-library: Delete topic and sub doesn't use the x-api-key token

### DIFF
--- a/pymod/ams.py
+++ b/pymod/ams.py
@@ -411,8 +411,7 @@ class AmsHttpRequests(object):
         except AmsException as e:
             raise e
 
-    def do_delete(self, url, route_name, retry=0, retrysleep=60,
-                retrybackoff=None, **reqkwargs):
+    def do_delete(self, url, route_name, **reqkwargs):
         """Delete method that is used to make the appropriate request.
 
            Used for (topics, subscriptions).
@@ -423,15 +422,22 @@ class AmsHttpRequests(object):
                reqkwargs: keyword argument that will be passed to underlying python-requests library call.
         """
         # try to send a delete request to the messaging service.
-
+        # if a connection problem araises a Connection error exception is raised.
         try:
-            return self._retry_make_request(url, body=None,
-                                            route_name=route_name, retry=retry,
-                                            retrysleep=retrysleep,
-                                            retrybackoff=retrybackoff,
-                                            **reqkwargs)
-        except AmsException as e:
-            raise e
+            # the delete request based on requests.
+            r = requests.delete(url, **reqkwargs)
+
+            # JSON error returned by AMS
+            if r.status_code != 200:
+                errormsg = self._error_dict(r.content, r.status_code)
+                raise AmsServiceException(json=errormsg, request=route_name)
+
+            else:
+                return True
+
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as e:
+            raise AmsConnectionException(e, route_name)
 
 
 class ArgoMessagingService(AmsHttpRequests):

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -196,12 +196,8 @@ class TestSubscription(unittest.TestCase):
                      self.submocks.create_subscription_mock,
                      self.topicmocks.get_topic_mock, self.submocks.get_sub_mock):
             topic = self.ams.topic('topic1')
-            # create sub
             sub = topic.subscription('subscription1')
-            self.assertTrue("/projects/TEST/subscriptions/subscription1" in self.ams.subs.keys())
-            # delete sub and check that it is removed
-            self.ams.delete_sub(sub="subscription1")
-            self.assertFalse("/projects/TEST/subscriptions/subscription1" in self.ams.subs.keys())
+            self.assertTrue(sub.delete())
 
     def testAcl(self):
         # Mock response for GET topic request

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -96,12 +96,8 @@ class TestTopic(unittest.TestCase):
 
         # Execute ams client with mocked response
         with HTTMock(delete_topic, self.topicmocks.create_topic_mock, self.topicmocks.has_topic_mock):
-            # create topic
             topic = self.ams.topic('topic1')
-            self.assertTrue("/projects/TEST/topics/topic1" in self.ams.topics.keys())
-            # delete topic and check that it is removed
-            self.ams.delete_topic(topic="topic1")
-            self.assertFalse("/projects/TEST/subscriptions/subscription1" in self.ams.topics.keys())
+            self.assertTrue(topic.delete())
 
     def testAcl(self):
         # Mock response for GET topic request


### PR DESCRIPTION
Reverts ARGOeu/argo-ams-library#140