### PR TITLE
Cap the version of `certifi` used below 2020.4.5.2 for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_ver():
 
 REQUIREMENTS = []
 if sys.version_info[0] == 2:
-    REQUIREMENTS = ['requests==2.20.0'],
+    REQUIREMENTS = ['requests==2.20.0', 'certifi<2020.4.5.2'],
 else:
     REQUIREMENTS = ['requests'],
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps = coverage
        httmock
        mock
        requests0: requests==2.20
+       requests0: certifi<2020.4.5.2
        requests260: requests==2.6.0
        requests2125: requests==2.12.5
 commands = coverage run --append -m pytest


### PR DESCRIPTION
APEL had a user open https://github.com/apel/ssm/issues/257, about a `SyntaxError` coming from `certifi`, which is a dependency of the `requests` module used by `argo-ams-library`.

Even though `argo-ams-library` has pinned `requests` at 2.20 for Python 2.7, this version of `requests` doesn't set a maximum version for `certifi`: https://github.com/psf/requests/blob/v2.20.0/setup.py#L48.

`certifi` version 2020.4.5.2 dropped Python 2 support: certifi/python-certifi@5efdd48. This meant that, while the `argo-ams-library` was installable under Python 2.7, it wasn't importable.

```
> pip install argo-ams-library
> python
>>> import argo_ams_library
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/argo_ams_library/__init__.py", line 11, in <module>
    from .ams import ArgoMessagingService
  File "/usr/lib/python2.7/site-packages/argo_ams_library/ams.py", line 4, in <module>
    import requests
  File "/usr/lib/python2.7/site-packages/requests/__init__.py", line 112, in <module>
    from . import utils
  File "/usr/lib/python2.7/site-packages/requests/utils.py", line 24, in <module>
    from . import certs
  File "/usr/lib/python2.7/site-packages/requests/certs.py", line 15, in <module>
    from certifi import where
  File "/usr/lib/python2.7/site-packages/certifi/__init__.py", line 1, in <module>
    from .core import contents, where
  File "/usr/lib/python2.7/site-packages/certifi/core.py", line 17
    def where() -> str:
                ^
SyntaxError: invalid syntax
```

This PR will cap the version of `certifi` used below 2020.4.5.2 for Python 2.7. I'm not sure if I have edited the tox.ini file in a sensible way.
